### PR TITLE
Add bs5 (ocaml 4.02.1) to deploy jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ jobs:
            overwrite: true
            draft: true
       - os: linux
-        env: COMPONENT=ppx-examples-test GENERATION=6
+        env: COMPONENT=ppx-examples-test GENERATION=5
         script: STAGE=deploy npm run travis
         deploy: *gh-release
       - os: osx
@@ -41,16 +41,16 @@ jobs:
         script: STAGE=deploy npm run travis
         deploy: *gh-release
       - os: osx
-        env: COMPONENT=ppx-examples-test GENERATION=6
+        env: COMPONENT=ppx-examples-test GENERATION=5
         script: STAGE=deploy npm run travis
         deploy: *gh-release
 
 env:
    - COMPONENT=ppx-examples-test
-   - COMPONENT=ppx-examples-test GENERATION=6
+   - COMPONENT=ppx-examples-test GENERATION=5
    - COMPONENT=ppx-examples-test GENERATION=latest
    - COMPONENT=runtime
-   - COMPONENT=runtime GENERATION=6
+   - COMPONENT=runtime GENERATION=5
    - COMPONENT=runtime GENERATION=latest
 
 # Allow failures on the upcoming major version of BuckleScript


### PR DESCRIPTION
After #7 we are not building with 4.02.1

Downgrading GENERATION during deploy job should fix this